### PR TITLE
Feature: Custom Facet Config

### DIFF
--- a/class-facetwp.php
+++ b/class-facetwp.php
@@ -196,7 +196,7 @@ final class WPGraphQL_FacetWP
         $field = $config['field'];
         $plural = $config['plural'];
 
-        register_graphql_connection([
+        $default_facet_connection_config = [
             'fromType'          => $field,
             'toType'            => $singular,
             'fromFieldName'     => lcfirst($plural),
@@ -210,7 +210,15 @@ final class WPGraphQL_FacetWP
                     ->set_query_arg('post__in', $source['results'])
                     ->get_connection();
             },
-        ]);
+        ];
+
+        $graphql_connection_config = apply_filters(
+            'facetwp_graphql_facet_connection_config',
+            $default_facet_connection_config,
+            $config
+        );
+
+        register_graphql_connection($graphql_connection_config);
     }
 
     /**

--- a/wp-graphql-facetwp.php
+++ b/wp-graphql-facetwp.php
@@ -69,3 +69,7 @@ add_action('admin_init', function () {
 		return false;
 	}
 });
+
+add_filter('facetwp_graphql_facet_connection_config', function (array $default_graphql_config) {
+	return $default_graphql_config;
+}, 10, 1);


### PR DESCRIPTION
Hi there, I added a custom filter that is called `facetwp_graphql_facet_connection_config` which allows developers to adjust the facet connection configuration. In my case I wanted to use the default woocommerce product graphql connection which is possible with the example in the docs.

Looking forward to your feedback!