### PR TITLE
Chore: Add .github repo files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Create a bug report for WPGraphQL for FacetWP
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thank you for taking the time to report a possible bug!
+
+        Please remember, a bug report is not the place to ask questions. You can
+        use Slack for that, or start a topic in [GitHub
+        Discussions](https://github.com/hsimah-services/wp-graphql-facetwp/discussions).
+  - type: input
+    attributes:
+      label: Description
+      description: >-
+        Please write a brief description of the bug, including what you expected
+        and what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to reproduce
+      description: >-
+        Please list the all the steps needed to reproduce the bug. Ideally, this
+        should be in the form of a GraphQL snippet that can be used in
+        WPGraphiQL IDE.
+      placeholder: >-
+        1. Go to "..."
+        2. Query:
+        ```graphql
+        query {
+
+        }
+        3. Result show X but should be Y
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: >-
+        Add any other context about the problem here, such as screenshots, error
+        logs, etc.
+  - type: input
+    attributes:
+      label: Plugin Version
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: FacetWP Version
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: WordPress Version
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: WPGraphQL Version
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional enviornmental details
+      description: PHP version, frontend framework, additional FacetWP extensions, etc.
+  - type: checkboxes
+    attributes:
+      label: Please confirm that you have searched existing issues in the repo.
+      description: >-
+        You can do this by searching
+        https://github.com/hsimah-services/wp-graphql-facetwp/issues and making sure the
+        bug is not related to another plugin.
+      options:
+        - label: 'Yes'
+          required: true
+  - type: checkboxes
+    attributes:
+      label: >-
+        Please confirm that you have disabled ALL plugins except for FacetWP, WPGraphQL, and WPGraphQL for FacetWP
+      options:
+        - label: 'Yes'
+          required: false
+        - label: My issue is with a specific 3rd-party plugin.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: General Support Request
+    url: https://github.com/hsimah-services/wp-graphql-facetwp/discussions
+    about: For general help requests, create a new topic in Github Discussions

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,40 @@
+name: Feature request
+description: Suggest an idea for WPGraphQL for FacetWP
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Thank you for taking the time to submit a feature request.
+
+
+        Please make sure to search the repo for [existing feature
+        requests](https://github.com/hsimah-services/wp-graphql-facetwp/issues)
+        before creating a new one.
+  - type: textarea
+    attributes:
+      label: What problem does this address?
+      description: >-
+        Please describe the problem you are trying to solve, including why you
+        think this is a problem.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is your proposed solution?
+      description: >-
+        Please provide a clear and concise description of your suggested
+        solution.
+      placeholder: What I'd like to see happen is [...]
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What alternatives have you considered?
+      description: >-
+        Please list any alternatives you have considered, and why you think your
+        solution is better.
+  - type: textarea
+    attributes:
+      label: Additional Context
+      description: Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+Thanks for taking the time to submit a Pull Request.
+-->
+
+## What
+<!-- In a few words, what does this PR actually change -->
+
+## Why
+<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
+
+## How
+<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->
+
+## Testing Instructions
+<!-- Please include step by step instructions on how to test this PR. -->
+<!-- 1. Open a Post or Page. -->
+<!-- 2. Insert a Heading Block. -->
+<!-- 3. etc. -->
+
+## Additional Info
+<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->
+
+## Checklist:
+<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
+- [ ] My code is tested to the best of my abilities.
+- [ ] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
+- [ ] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->

--- a/.github/workflows/code-standard.yml
+++ b/.github/workflows/code-standard.yml
@@ -1,0 +1,42 @@
+name: WordPress Coding Standards
+
+on:
+  push:
+    branches:
+      - develop
+      - main
+  pull_request:
+    branches:
+      - develop
+      - main
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    name: Checkout repo
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.0
+          extensions: mbstring, intl
+          tools: composer
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Run PHP_CodeSniffer
+        run: composer run-script check-cs


### PR DESCRIPTION
This PR adds templates for issues and pull requests, and a workflow for `phpcs` linting.

## Notes:
- Other workflows are dependent on an actual WordPress install, which will require adding a GH secret to the repo to access a copy of `facetwp` for installation.
- The templates are written under the assumption that GitHub discussions will be enabled for the repo.
- The workflows are written under the assumption that a `main` <- `dev` <- `pr-branch` merge flow will be adopted for the repo.