### PR TITLE
ci: use label to run pull_request_target

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -36,5 +36,5 @@ WORDPRESS_DB_PASSWORD=${DB_PASSWORD}
 WORDPRESS_DB_NAME=${DB_NAME}
 
 # FacetWP is a commercial plugin. Our tests use a private GH repo.
-# FACET_REPO =
+FACET_REPO=github.com/AxeWP/facetwp
 # GIT_TOKEN =

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - develop
       - main
-  pull_request:
-    branches:
-      - main
   pull_request_target:
     branches:
       - develop
+      - main
+
 jobs:
   run:
     runs-on: ubuntu-latest
     name: Check code
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test ✔')
+
     services:
       mariadb:
         image: mariadb
@@ -26,30 +27,29 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
+          tools: composer:v2, wp-cli
           coverage: none
-          tools: composer, wp-cli
-
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v3
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: php-${{ matrix.php }}-${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-${{ matrix.php }}N-${{ runner.os }}-composer
 
       - name: Install dependencies
-        run: composer install
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--no-progress"
 
       - name: Setup WordPress
         run: |

--- a/.github/workflows/code-standard.yml
+++ b/.github/workflows/code-standard.yml
@@ -9,11 +9,18 @@ on:
     branches:
       - develop
       - main
+
 jobs:
   run:
     runs-on: ubuntu-latest
     name: Checkout repo
     steps:
+      - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -24,19 +31,10 @@ jobs:
           extensions: mbstring, intl
           tools: composer
 
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Cache dependencies
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: ${{ runner.os }}-composer
-
       - name: Install dependencies
-        run: composer install
+        uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--no-progress"
 
       - name: Run PHP_CodeSniffer
         run: composer run-script check-cs

--- a/.github/workflows/schema-linter.yml
+++ b/.github/workflows/schema-linter.yml
@@ -5,16 +5,17 @@ on:
     branches:
       - develop
       - main
-  pull_request:
-    branches:
-      - main
   pull_request_target:
     branches:
       - develop
+      - main
+
 jobs:
   run:
     runs-on: ubuntu-latest
     name: Lint WPGraphQL Schema
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test ✔')
+
     services:
       mariadb:
         image: mariadb
@@ -24,9 +25,18 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         # Ensure docker waits for mariadb to start
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
     steps:
+    - name: Cancel previous runs of this workflow (pull requests only)
+        if: ${{ github.event_name == 'pull_request_target' }}
+        uses: styfle/cancel-workflow-action@0.5.0
+        with:
+          access_token: ${{ github.token }}
+
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup PHP w/ Composer & WP-CLI
         uses: shivammathur/setup-php@v2
@@ -34,7 +44,7 @@ jobs:
           php-version: 8.0
           extensions: mbstring, intl, bcmath, exif, gd, mysqli, opcache, zip, pdo_mysql
           coverage: none
-          tools: composer, wp-cli
+          tools: composer:v2, wp-cli
 
       - name: Setup Node.js
         uses: actions/setup-node@v1


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->
Runs GH Actions on pull requests with the `safe to test ✔` label.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
Since we need to use `pull_request_target` to test against FacetWP with a repo secret, we need a secure way to [avoid pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/).

## How
- ci: only run `pull_request_target` when the  `safe to test ✔` label is applied.
- ci: use `ramsey/composer-install@v2` to cache dependencies.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
