### PR TITLE
chore: bump version to 0.3.0.1

### DIFF
--- a/wp-graphql-facetwp.php
+++ b/wp-graphql-facetwp.php
@@ -6,14 +6,14 @@
  * Description: WP GraphQL provider for FacetWP
  * Author: hsimah
  * Author URI: http://www.hsimah.com
- * Version: 0.2.0
+ * Version: 0.3.0.1
  * Text Domain: wpgraphql-facetwp
  * License: GPL-3
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  *
  * @package  WPGraphQL_FacetWP
  * @author   hsimah
- * @version  0.2.0
+ * @version  0.3.0.1
  */
 
 // Exit if accessed directly.


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
Bumps the _pre-refactored_ plugin version to `v0.3.0.1`

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->
`v0.3.0` was released without bumping the version number from `0.2.0`. While normally this wouldn't be a big enough deal to backfill a release, because of the significant changes in #28 we want to make it clear what version users are actually using.


## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
