### PR TITLE
dev: run plugin on `facetwp_init`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-
+- dev: initialize plugin using `facetwp_init` hook.
 - dev!: Refactor GraphQL type classes to use `axepress/wp-graphql-plugin-boilerplate`.
 - tests: backfill tests for `Main` class.
 

--- a/wp-graphql-facetwp.php
+++ b/wp-graphql-facetwp.php
@@ -138,7 +138,7 @@ if ( ! function_exists( 'graphql_facetwp_init' ) ) {
 	}
 }
 
-add_action( 'graphql_init', 'graphql_facetwp_init' );
+add_action( 'facetwp_init', 'graphql_facetwp_init' );
 
 
 add_filter(


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Changes the plugin to run on `facetwp_init` instead of `graphql_init`.

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Ensures FWP() properties are set.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
