### PR TITLE
feat: add plugin dependencies header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- feat: Add WPGraphQL to Plugin Dependencies header.
 - chore: Implement strict phpstan rules and lint.
 - chore: Update Composer dependencies and lint.
 - ci: Test against WP 6.5.

--- a/wp-graphql-facetwp.php
+++ b/wp-graphql-facetwp.php
@@ -3,12 +3,13 @@
  * Plugin Name: WPGraphQL for FacetWP
  * Plugin URI: https://github.com/hsimah-services/wp-graphql-facetwp
  * Description: Adds FacetWP support to WPGraphQL
- * Author: hsimah
+ * Author: hsimah, justlevine
  * Author URI: http://www.hsimah.com
  * Version: 0.4.4
  * Text Domain: wpgraphql-facetwp
  * Requires at least: 5.4.1
  * Requires PHP: 7.4
+ * Requires Plugins: wp-graphql
  * WPGraphQL requires at least: 1.6.0
  * FacetWP requires at least: 4.0
  * Tested up to: 6.5


### PR DESCRIPTION
<!--
Thanks for taking the time to submit a Pull Request.
-->

## What
<!-- In a few words, what does this PR actually change -->

Adds support for WP6.5's Plugin Dependencies header. 

## Why
<!-- Why is this PR necessary? Please any existing previous issue(s) or PR(s) and include a short summary here, too -->

Ensures WPGraphQL is activated in WP 6.5+, and makes it easy to install if it isn't.

## How
<!-- How is your PR addressing the issue at hand? What are the implementation details?  -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a Post or Page. -->
<!-- 2. Insert a Heading Block. -->
<!-- 3. etc. -->

## Additional Info
<!-- Please include any relevant logs, error output, GraphiQL screenshots, etc -->

## Checklist:
<!-- We encourage you to complete this checklist to the best of your abilities. If you can't do everything, that's okay too.  -->
- [x] My code is tested to the best of my abilities.
- [x] My code follows the WordPress Coding Standards. <!-- Check code: `composer run check-cs`, Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/php/ -->
- [x] My code has proper inline documentation. <!-- Guidelines: https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/ -->
- [x] I have added unit tests to verify the code works as intended.
- [x] The changes in this PR have been noted in CHANGELOG.md
